### PR TITLE
[Feature] Add randint for generating unsinged integers of every size

### DIFF
--- a/randint/randint.go
+++ b/randint/randint.go
@@ -37,7 +37,7 @@ func Uint16() (uint16, error) {
 		return 0, err
 	}
 
-	return binary.LittleEndian.Uint16(b), nil
+	return binary.NativeEndian.Uint16(b), nil
 }
 
 func Uint32() (uint32, error) {
@@ -46,7 +46,7 @@ func Uint32() (uint32, error) {
 		return 0, err
 	}
 
-	return binary.LittleEndian.Uint32(b), nil
+	return binary.NativeEndian.Uint32(b), nil
 }
 
 func Uint64() (uint64, error) {
@@ -55,5 +55,5 @@ func Uint64() (uint64, error) {
 		return 0, err
 	}
 
-	return binary.LittleEndian.Uint64(b), nil
+	return binary.NativeEndian.Uint64(b), nil
 }

--- a/randint/randint.go
+++ b/randint/randint.go
@@ -1,0 +1,59 @@
+package randint
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+)
+
+const (
+	uint8Len  = 1
+	uint16Len = 2
+	uint32Len = 4
+	uint64Len = 8
+)
+
+func generateBytes(length int) ([]byte, error) {
+	b := make([]byte, length)
+
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func Uint8() (uint8, error) {
+	b, err := generateBytes(uint8Len)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint8(b[0]), nil
+}
+
+func Uint16() (uint16, error) {
+	b, err := generateBytes(uint16Len)
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint16(b), nil
+}
+
+func Uint32() (uint32, error) {
+	b, err := generateBytes(uint32Len)
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint32(b), nil
+}
+
+func Uint64() (uint64, error) {
+	b, err := generateBytes(uint64Len)
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint64(b), nil
+}

--- a/randint/randint_test.go
+++ b/randint/randint_test.go
@@ -1,0 +1,64 @@
+package randint
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUint8(t *testing.T) {
+	t.Parallel()
+
+	// arrange
+	assert := require.New(t)
+
+	// act
+	v, err := Uint8()
+
+	// assert
+	assert.NoError(err)
+	assert.Equal(uint8Len, int(unsafe.Sizeof(v)))
+}
+
+func TestUint16(t *testing.T) {
+	t.Parallel()
+
+	// arrange
+	assert := require.New(t)
+
+	// act
+	v, err := Uint16()
+
+	// assert
+	assert.NoError(err)
+	assert.Equal(uint16Len, int(unsafe.Sizeof(v)))
+}
+
+func TestUint32(t *testing.T) {
+	t.Parallel()
+
+	// arrange
+	assert := require.New(t)
+
+	// act
+	v, err := Uint32()
+
+	// assert
+	assert.NoError(err)
+	assert.Equal(uint32Len, int(unsafe.Sizeof(v)))
+}
+
+func TestUint64(t *testing.T) {
+	t.Parallel()
+
+	// arrange
+	assert := require.New(t)
+
+	// act
+	v, err := Uint64()
+
+	// assert
+	assert.NoError(err)
+	assert.Equal(uint64Len, int(unsafe.Sizeof(v)))
+}


### PR DESCRIPTION
This pull request introduces the `randint` package.
It's main purpose is to offer utility functions as a shortcut for generating cryptographically secure pseudo-random unsigned integers.

It includes the following functions

* `randint.Uint8`
* `randint.Uint16`
* `randint.Uint32`
* `randint.Uint64`